### PR TITLE
Update NaiveBayes.php

### DIFF
--- a/src/Phpml/Classification/NaiveBayes.php
+++ b/src/Phpml/Classification/NaiveBayes.php
@@ -68,6 +68,8 @@ class NaiveBayes implements Classifier
 
         $labelCounts = array_count_values($this->targets);
         $this->labels = array_keys($labelCounts);
+        $this->labels = array_map('strval', $this->labels);
+            
         foreach ($this->labels as $label) {
             $samples = $this->getSamplesByLabel($label);
             $this->p[$label] = count($samples) / $this->sampleCount;


### PR DESCRIPTION
This fixes an issue using string labels that are string representations of integers, e.g. "1998" getting cast to (int)1998.